### PR TITLE
Fix gcc implicit fallthrough warning

### DIFF
--- a/libs/jsoncpp-1.7.7/src/lib_json/json_reader.cpp
+++ b/libs/jsoncpp-1.7.7/src/lib_json/json_reader.cpp
@@ -1232,6 +1232,7 @@ bool OurReader::readToken(Token& token) {
     ok = readStringSingleQuote();
     break;
     } // else continue
+    // FALLTHRU
   case '/':
     token.type_ = tokenComment;
     ok = readComment();


### PR DESCRIPTION
The warning (error on polybar) occurs only if the system doesn't have
jsoncpp 1.7.7 or higher installed and jsoncpp is compiled from the
source included in the repo.
The comment marker was used instead of `__attribute__ ((fallthrough))`
so that it cleanly compiles with both gcc and clang

Fixes https://github.com/jaagr/polybar/issues/753