### PR TITLE
fix(gcc): Fix -Wstringop-truncation warning

### DIFF
--- a/src/ipc-util.cpp
+++ b/src/ipc-util.cpp
@@ -34,7 +34,7 @@ buf_t::buf_t(uint32_t  payload_size) : size(sizeof(header_t) + payload_size) {
 	data = new uint8_t[size];
 	header = (header_t*)data;
 	payload = (char*)(data + sizeof(header_t));
-	strncpy(header->magic, g_i3_ipc_magic.c_str(), sizeof(header->magic));
+	memcpy(header->magic, g_i3_ipc_magic.c_str(), sizeof(header->magic));
 	header->size = payload_size;
 	header->type = 0x0;
 }


### PR DESCRIPTION
As mentioned in [1], gcc >=8 will complain, if strncpy truncates the
source string or gcc can prove there is no NUL terminating byte.

The header_t.magic field is a non-NUL terminated 6 byte string, so we
use memcpy here

[1] https://github.com/jaagr/polybar/issues/1215