### PR TITLE
Fix memory leak

### DIFF
--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -23,12 +23,11 @@ std::vector<std::ostream*>  g_logging_err_outs = {
 #define IPC_JSON_READ(ROOT) \
 { \
 	Json::CharReaderBuilder b; \
-	Json::CharReader* reader(b.newCharReader()); \
+	const std::unique_ptr<Json::CharReader> reader(b.newCharReader());	\
 	JSONCPP_STRING error; \
 	if(!reader->parse(buf->payload, buf->payload + buf->header->size, &ROOT, &error)) { \
 		throw invalid_reply_payload_error(auss_t() << "Failed to parse reply on \"" i3IPC_TYPE_STR "\": " << error); \
 	} \
-	delete reader; \
 }
 
 #define IPC_JSON_ASSERT_TYPE(OBJ, OBJ_DESCR, TYPE_CHECK, TYPE_NAME) \


### PR DESCRIPTION
Wrap raw pointer into std::unique_ptr which would gracefully handle
deallocation when reader->parse finishes with error.