### PR TITLE
Fix assertion error in get_socketpath

### DIFF
--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -265,7 +265,7 @@ std::string  get_socketpath() {
 		pclose(in);
 		str = str_buf;
 	}
-	if (str.back() == '\n') {
+	if (!str.empty() && str.back() == '\n') {
 		str.pop_back();
 	}
 	return str;


### PR DESCRIPTION
If `str` in `get_socketpath` was empty, the function tried to access the
last character and would access outside of the buffer (undefined
behavior).

With the `_GLIBCXX_ASSERTIONS` macro set, this would trigger an abort.

Ref: https://github.com/polybar/polybar/issues/2416